### PR TITLE
small typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ I files generati da questo comando devono essere configurati nel file config/aut
 ```
     'nomeservizio-sp' => array(
         'saml:SP',
-        'privatekey' => 'saml.pem',
-        'certificate' => 'saml.crt',
+        'privatekey' => 'spid-sp.pem',
+        'certificate' => 'spid-sp.crt',
         // The entity ID of this SP.
         // Can be NULL/unset, in which case an entity ID is generated based on the metadata URL.
         'entityID' => null,


### PR DESCRIPTION
Piccola inconsistenza nel README (poco sopra si parlava di `spid-sp.pem`).