### PR TITLE
Deactivate memcached support

### DIFF
--- a/config-templates/config-spid.php
+++ b/config-templates/config-spid.php
@@ -683,7 +683,7 @@ $config = array(
      *
      * (This option replaces the old 'session.handler'-option.)
      */
-    'store.type'                    => 'memcache',
+    'store.type'                    => 'phpsession',
 
     /*
      * The DSN the sql datastore should connect to.


### PR DESCRIPTION
Turn back to development default (phpsession). Memcache requires to install the memcached daemon and a PHP library (Memcache); the process is not documented in the installation instructions and I wasn't able to even find the correct PHP library and/or install (there were always conflicts of dependencies). I think that for development purposes, it's better to use the default that requires less dependencies.

Fixes #5.